### PR TITLE
Scripts: Drop comparator-limit usage in conditions.

### DIFF
--- a/scripts/demonhunter.lua
+++ b/scripts/demonhunter.lua
@@ -73,7 +73,7 @@ AddFunction VengeanceRangeCheck
     if (CheckBoxOn(opt_melee_range) and not target.InRange(soul_cleave))
     {
         if (target.InRange(felblade)) Spell(felblade)
-        if (CheckBoxOn(opt_infernal_strike) and (target.Distance(more 5) and target.Distance(atMost 30))) Spell(infernal_strike text=range)
+        if (CheckBoxOn(opt_infernal_strike) and (target.Distance() > 5 and target.Distance() <= 30)) Spell(infernal_strike text=range)
         Texture(misc_arrowlup help=L(not_in_melee_range))
     }
 }

--- a/scripts/druid.lua
+++ b/scripts/druid.lua
@@ -249,9 +249,9 @@ AddFunction GuardianInterruptActions
         if not target.Classification(worldboss)
         {
             Spell(mighty_bash)
-            if target.distance(less 10) spell(incapacitating_roar)
-            if target.Distance(less 8) Spell(war_stomp)
-            if target.Distance(less 15) Spell(typhoon)
+            if (target.distance() < 10) spell(incapacitating_roar)
+            if (target.Distance() < 8) Spell(war_stomp)
+            if (target.Distance() < 15) Spell(typhoon)
         }
     }
 }

--- a/scripts/monk.lua
+++ b/scripts/monk.lua
@@ -261,8 +261,8 @@ AddFunction BrewmasterInterruptActions
         if target.InRange(spear_hand_strike) and target.IsInterruptible() Spell(spear_hand_strike)
         if not target.Classification(worldboss)
         {
-            if target.Distance(less 5) Spell(leg_sweep)
-            if target.Distance(less 5) Spell(war_stomp)
+            if (target.Distance() < 5) Spell(leg_sweep)
+            if (target.Distance() < 5) Spell(war_stomp)
             if target.InRange(quaking_palm) Spell(quaking_palm)
             if target.InRange(paralysis) Spell(paralysis)
         }

--- a/scripts/paladin.lua
+++ b/scripts/paladin.lua
@@ -133,8 +133,8 @@ AddFunction ProtectionInterruptActions
         if not target.Classification(worldboss)
         {
             if target.InRange(hammer_of_justice) Spell(hammer_of_justice)
-            if target.Distance(less 10) Spell(blinding_light)
-            if target.Distance(less 8) Spell(war_stomp)
+            if (target.Distance() < 10) Spell(blinding_light)
+            if (target.Distance() < 8) Spell(war_stomp)
         }
     }
 }

--- a/scripts/warrior.lua
+++ b/scripts/warrior.lua
@@ -101,7 +101,7 @@ AddFunction ProtectionGetInMeleeRange
     if CheckBoxOn(opt_melee_range) and not InFlightToTarget(charge) and not InFlightToTarget(intervene) and not InFlightToTarget(heroic_leap) and not target.InRange(pummel)
     {
         if target.InRange(charge) Spell(charge)
-        if target.Distance(atLeast 8) and target.Distance(atMost 40) Spell(heroic_leap)
+        if (target.Distance() >= 8 and target.Distance() <= 40) Spell(heroic_leap)
         Texture(misc_arrowlup help=L(not_in_melee_range))
     }
 }
@@ -184,9 +184,9 @@ AddFunction ProtectionInterruptActions
         if not target.Classification(worldboss) 
         {
             if target.InRange(storm_bolt) Spell(storm_bolt)
-            if target.Distance(less 10) Spell(shockwave)
+            if (target.Distance() < 10) Spell(shockwave)
             if target.InRange(quaking_palm) Spell(quaking_palm)
-            if target.Distance(less 5) Spell(war_stomp)
+            if (target.Distance() < 5) Spell(war_stomp)
             if target.InRange(intimidating_shout) Spell(intimidating_shout)
         }
     }


### PR DESCRIPTION
The "less", "more", "atLeast", and "atMost" comparators have been
removed in recent versions of Ovale. Replace them with direct
arithmetic comparison operators.