### PR TITLE
Apply DRY principle to script files and handle changes in Ovale API.

### DIFF
--- a/Ovale_TankScripts.lua
+++ b/Ovale_TankScripts.lua
@@ -1,20 +1,48 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc and ovale.ioc.scripts
+local ADDON_NAME, Private = ...
 
--- Overwrite default script selection for tank classes.
-local baseGetDefaultScriptName = OvaleScripts.getDefaultScriptName
-OvaleScripts.getDefaultScriptName = function(self, className, specialization)
-    --print("Ovale_TankScripts GetDefaultScriptName")
-    if false
-        or (className == "DEATHKNIGHT" and specialization == "blood") 
-        or (className == "DEMONHUNTER" and specialization == "vengeance") 
-        or (className == "DRUID" and specialization == "guardian")
-        or (className == "MONK" and specialization == "brewmaster") 
-        or (className == "PALADIN" and specialization == "protection")
-        or (className == "WARRIOR" and specialization == "protection")
-    then
-        return format("ovale_tankscripts_%s_%s", string.lower(className), specialization)
-    else
-        return baseGetDefaultScriptName(self, className, specialization)
+local ovale = LibStub and LibStub:GetLibrary("ovale")
+local scripts = ovale and ovale.ioc and ovale.ioc.scripts
+
+if scripts then
+    -- Export
+    Private.name = ADDON_NAME
+    Private.scripts = scripts
+    Private.initialized = true
+
+    local baseGetDefaultScriptName = scripts.getDefaultScriptName
+    do
+        -- Ovale<=9.0.43
+        if not baseGetDefaultScriptName then
+	        baseGetDefaultScriptName = scripts.GetDefaultScriptName
+        end
+    end
+
+    local getDefaultScriptName = function(self, className, specialization)
+        if false
+            or (className == "DEATHKNIGHT" and specialization == "blood") 
+            or (className == "DEMONHUNTER" and specialization == "vengeance") 
+            or (className == "DRUID" and specialization == "guardian")
+            or (className == "MONK" and specialization == "brewmaster") 
+            or (className == "PALADIN" and specialization == "protection")
+            or (className == "WARRIOR" and specialization == "protection")
+        then
+            return format("ovale_tankscripts_%s_%s", string.lower(className), specialization)
+        else
+            return baseGetDefaultScriptName(self, className, specialization)
+        end
+    end
+
+    -- Overwrite default script selection function.
+    if scripts.getDefaultScriptName then
+        scripts.getDefaultScriptName = getDefaultScriptName
+    end
+    do
+        -- Ovale<=9.0.43
+        if scripts.GetDefaultScriptName then
+            scripts.GetDefaultScriptName = getDefaultScriptName
+        end
+        if not scripts.registerScript then
+            scripts.registerScript = scripts.RegisterScript
+        end
     end
 end

--- a/Ovale_TankScripts.toc
+++ b/Ovale_TankScripts.toc
@@ -6,5 +6,5 @@
 ## RequiredDeps: Ovale
 
 libs\libs.xml
-scripts\files.xml
 Ovale_TankScripts.lua
+scripts\files.xml

--- a/scripts/common.lua
+++ b/scripts/common.lua
@@ -1,8 +1,8 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc.scripts
-do
+local _, Private = ...
+
+if Private.initialized then
     local name = "ovale_tankscripts_common"
-    local desc = "[9.0.2] Ovale_TankScripts: Common"
+    local desc = string.format("[9.0.2] %s: Common", Private.name)
     local code = [[
 Include(ovale_common)
 
@@ -34,5 +34,5 @@ AddFunction CovenantDispelActions
 }
 
 ]]
-    OvaleScripts:registerScript(nil, nil, name, desc, code, "include")
+    Private.scripts:registerScript(nil, nil, name, desc, code, "include")
 end

--- a/scripts/deathknight.lua
+++ b/scripts/deathknight.lua
@@ -1,8 +1,8 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc.scripts
-do
+local _, Private = ...
+
+if Private.initialized then
     local name = "ovale_tankscripts_deathknight_blood"
-    local desc = "[9.0.2] Ovale_TankScripts: Death Knight Blood"
+    local desc = string.format("[9.0.2] %s: Death Knight Blood", Private.name)
     local code = [[
 # Adapted from "[9.0] Advanced Blood Death Knight Guide for M+"
 #   by Kyrasis-Stormreaver.
@@ -403,5 +403,5 @@ AddIcon size=small enabled=(CheckBoxOn(opt_deathknight_blood_offensive))
     BloodDefaultOffensiveActions()
 }
 ]]
-    OvaleScripts:registerScript("DEATHKNIGHT", "blood", name, desc, code, "script")
+    Private.scripts:registerScript("DEATHKNIGHT", "blood", name, desc, code, "script")
 end

--- a/scripts/demonhunter.lua
+++ b/scripts/demonhunter.lua
@@ -1,8 +1,8 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc.scripts
-do
+local _, Private = ...
+
+if Private.initialized then
     local name = "ovale_tankscripts_demonhunter_vengeance"
-    local desc = "[9.0.2] Ovale_TankScripts: DemonHunter Vengeance"
+    local desc = string.format("[9.0.2] %s: DemonHunter Vengeance", Private.name)
     local code = [[
 Include(ovale_common)
 Include(ovale_tankscripts_common)
@@ -199,5 +199,5 @@ AddIcon size=small enabled=(checkboxon(opt_demonhunter_vengeance_offensive) and 
     VengeanceDefaultOffensiveActions()
 }
     ]]
-    OvaleScripts:registerScript("DEMONHUNTER", "vengeance", name, desc, code, "script")
+    Private.scripts:registerScript("DEMONHUNTER", "vengeance", name, desc, code, "script")
 end

--- a/scripts/druid.lua
+++ b/scripts/druid.lua
@@ -1,8 +1,8 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc.scripts
-do
+local _, Private = ...
+
+if Private.initialized then
     local name = "ovale_tankscripts_druid_guardian"
-    local desc = "[9.0.2] Ovale_TankScripts: Druid Guardian"
+    local desc = string.format("[9.0.2] %s: Druid Guardian", Private.name)
     local code = [[
 Include(ovale_common)
 Include(ovale_tankscripts_common)
@@ -308,5 +308,5 @@ AddIcon size=small enabled=(checkboxon(opt_druid_guardian_offensive) and special
     GuardianDefaultOffensiveActions()
 }
 ]]
-    OvaleScripts:registerScript("DRUID", "guardian", name, desc, code, "script")
+    Private.scripts:registerScript("DRUID", "guardian", name, desc, code, "script")
 end

--- a/scripts/monk.lua
+++ b/scripts/monk.lua
@@ -1,8 +1,8 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc.scripts
-do
+local _, Private = ...
+
+if Private.initialized then
     local name = "ovale_tankscripts_monk_brewmaster"
-    local desc = "[9.0.2] Ovale_TankScripts: Monk Brewmaster"
+    local desc = string.format("[9.0.2] %s: Monk Brewmaster", Private.name)
     local code = [[
 # Adapted from Wowhead's "Brewmaster Monk Rotation Guide - Shadowlands 9.0.2"
 #   by Llarold-Area52
@@ -314,5 +314,5 @@ AddIcon size=small enabled=(CheckBoxOn(opt_monk_bm_offensive))
     BrewmasterDefaultOffensiveActions()
 }
 ]]
-    OvaleScripts:registerScript("MONK", "brewmaster", name, desc, code, "script")
+    Private.scripts:registerScript("MONK", "brewmaster", name, desc, code, "script")
 end

--- a/scripts/paladin.lua
+++ b/scripts/paladin.lua
@@ -1,8 +1,8 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc.scripts
-do
+local _, Private = ...
+
+if Private.initialized then
     local name = "ovale_tankscripts_paladin_protection"
-    local desc = "[9.0.2] Ovale_TankScripts: Paladin Protection"
+    local desc = string.format("[9.0.2] %s: Paladin Protection", Private.name)
     local code = [[
 Include(ovale_common)
 Include(ovale_tankscripts_common)
@@ -195,5 +195,5 @@ AddIcon size=small enabled=(checkboxon(opt_paladin_protection_offensive) and spe
     ProtectionDefaultOffensiveActions()
 }
     ]]
-    OvaleScripts:registerScript("PALADIN", "protection", name, desc, code, "script")
+    Private.scripts:registerScript("PALADIN", "protection", name, desc, code, "script")
 end

--- a/scripts/warrior.lua
+++ b/scripts/warrior.lua
@@ -1,8 +1,8 @@
-local ovale = LibStub:GetLibrary("ovale")
-local OvaleScripts = ovale.ioc.scripts
-do
+local _, Private = ...
+
+if Private.initialized then
     local name = "ovale_tankscripts_warrior_protection"
-    local desc = "[9.0.2] Ovale_TankScripts: Warrior Protection"
+    local desc = string.format("[9.0.2] %s: Warrior Protection", Private.name)
     local code = [[
 Include(ovale_common)
 Include(ovale_tankscripts_common)
@@ -235,5 +235,5 @@ AddIcon size=small enabled=(checkboxon(opt_warrior_protection_offensive) and spe
     ProtectionDefaultOffensiveActions()
 }
 ]]
-    OvaleScripts:registerScript("WARRIOR", "protection", name, desc, code, "script")
+    Private.scripts:registerScript("WARRIOR", "protection", name, desc, code, "script")
 end


### PR DESCRIPTION
Instead of doing a lookup of the Ovale scripts module in each
script file, do the lookup once and stash it in the addon table to
be reused. This makes it easier to adapt to changes to the Ovale
API in future releases.

Gracefully interoperate with older versions of Ovale so that this
addon will work even if someone forcibly installs an older version
of Ovale.